### PR TITLE
Time Series

### DIFF
--- a/backend/build.sbt
+++ b/backend/build.sbt
@@ -39,7 +39,6 @@ lazy val commonSettings = Seq(
   },
   shellPrompt := { s => Project.extract(s).currentProject.id + " > " },
   resolvers  ++= Seq(
-    "Location Tech GeoTrellis Snapshots" at "https://repo.locationtech.org/content/repositories/geotrellis-snapshots",
     Resolver.mavenLocal
   )
 )

--- a/backend/gddp/src/main/scala/Gddp.scala
+++ b/backend/gddp/src/main/scala/Gddp.scala
@@ -87,7 +87,6 @@ object Gddp {
     netcdfUri: String,
     extent: java.util.ArrayList[Double],
     days: java.util.ArrayList[Int],
-    baseInstant: Int,
     sc: SparkContext
   ) = {
     val List(xSliceStart, xSliceStop, ySliceStart, ySliceStop) = extentToIndices(extent)
@@ -107,7 +106,7 @@ object Gddp {
           val ucarType = tasmin.getDataType()
 
           itr.map({ t =>
-            val key = SpaceTimeKey(0, 0, t*millisPerDay + baseInstant)
+            val key = SpaceTimeKey(0, 0, t)
             val array = tasmin
               .read(s"$t,$ySliceStart:$ySliceStop,$xSliceStart:$xSliceStop")
               .get1DJavaArray(ucarType).asInstanceOf[Array[Float]]

--- a/geopyspark_netcdf/datasets.py
+++ b/geopyspark_netcdf/datasets.py
@@ -15,7 +15,7 @@ class Gddp(object):
     y_offset = (-90.0 + 1/8.0)
 
     @classmethod
-    def rdd_of_rasters(cls, uri, extent, days, base_instant):
+    def rdd_of_rasters(cls, uri, extent, days):
 
         if not isinstance(uri, str):
             raise Exception
@@ -26,7 +26,7 @@ class Gddp(object):
         float_extent = list(map(lambda coord: float(coord), extent))
 
         jvm = sc._gateway.jvm
-        rdd = jvm.geopyspark.netcdf.datasets.Gddp.rasters(uri, float_extent, int_days, base_instant, sc._jsc.sc())
+        rdd = jvm.geopyspark.netcdf.datasets.Gddp.rasters(uri, float_extent, int_days, sc._jsc.sc())
         return TiledRasterLayer(LayerType.SPACETIME, rdd)
 
     @classmethod


### PR DESCRIPTION
Remove `base_instant` parameter from the `rdd_of_rasters` method and remove overflow-causing multiplication of day index by the number milliseconds per day.