### PR TITLE
num partitions Parameter for rdd_of_rasters

### DIFF
--- a/backend/gddp/build.sbt
+++ b/backend/gddp/build.sbt
@@ -1,7 +1,7 @@
 name := "gddp"
 
 libraryDependencies ++= Seq(
-  "geopyspark.geotrellis"        % "geotrellis-backend"   % "0.1.0" % "provided" from "file:///tmp/geotrellis-backend-assembly-0.2.2.jar",
+  "geopyspark.geotrellis"        % "geotrellis-backend"   % "0.2.0" % "provided" from "file:///tmp/geotrellis-backend-assembly-0.2.2.jar",
   "org.apache.hadoop"            % "hadoop-client"        % "2.7.3" % "provided",
   "org.apache.spark"            %% "spark-core"           % "2.1.0" % "provided",
   "edu.ucar"                     % "cdm"                  % "5.0.0-SNAPSHOT" from "file:///tmp/netcdfAll-5.0.0-SNAPSHOT.jar",

--- a/geopyspark_netcdf/datasets.py
+++ b/geopyspark_netcdf/datasets.py
@@ -15,7 +15,7 @@ class Gddp(object):
     y_offset = (-90.0 + 1/8.0)
 
     @classmethod
-    def rdd_of_rasters(cls, uri, extent, days):
+    def rdd_of_rasters(cls, uri, extent, days, num_partitions=None):
 
         if not isinstance(uri, str):
             raise Exception
@@ -26,7 +26,7 @@ class Gddp(object):
         float_extent = list(map(lambda coord: float(coord), extent))
 
         jvm = sc._gateway.jvm
-        rdd = jvm.geopyspark.netcdf.datasets.Gddp.rasters(uri, float_extent, int_days, sc._jsc.sc())
+        rdd = jvm.geopyspark.netcdf.datasets.Gddp.rasters(uri, float_extent, int_days, num_partitions, sc._jsc.sc())
         return TiledRasterLayer(LayerType.SPACETIME, rdd)
 
     @classmethod


### PR DESCRIPTION
This PR adds the `num_partitions` parameter to the `rdd_of_rasters` method. This will allow users to input the desired number of partitions more easily.

This PR resolves #19 